### PR TITLE
Fix Display Technical names.

### DIFF
--- a/ItemTooltips.cs
+++ b/ItemTooltips.cs
@@ -14,8 +14,8 @@ namespace WMITF
 				{
 					if(item.ModItem != null && !item.Name.Contains("[" + item.ModItem.Mod.Name + "]") && !item.Name.Contains("[" + item.ModItem.Mod.DisplayName + "]"))
 					{
-						string text = ModContent.GetInstance<Config>().DisplayTechnicalNames ? (item.ModItem.Mod.Name + ":" + item.ModItem.Name) : item.ModItem.Mod.DisplayName;
-						TooltipLine line = new (Mod, Mod.Name, "[" + text + "]");
+						string text = ModContent.GetInstance<Config>().DisplayTechnicalNames ? (item.ModItem.Name + ":" + item.ModItem.Mod.Name) : item.ModItem.Mod.DisplayName;
+						TooltipLine line = new (Mod, "WMITF_" + Mod.Name, "[" + text + "]");
 						line.OverrideColor = Colors.RarityBlue;
 						tooltips.Add(line);
 					}

--- a/WorldTooltips.cs
+++ b/WorldTooltips.cs
@@ -76,7 +76,7 @@ namespace WMITF
                     var modNPC = NPCLoader.GetNPC(npc.type);
                     if (modNPC != null && npc.active && !NPCID.Sets.ProjectileNPC[npc.type])
                     {
-                        WMITFModSystem.MouseText = ModContent.GetInstance<Config>().DisplayTechnicalNames ? (modNPC.Mod.Name + ":" + modNPC.Name) : modNPC.Mod.DisplayName;
+                        WMITFModSystem.MouseText = ModContent.GetInstance<Config>().DisplayTechnicalNames ? (modNPC.Name + ":" + modNPC.Mod.Name ) : modNPC.Mod.DisplayName;
                         WMITFModSystem.SecondLine = true;
                         break;
                     }

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 ﻿displayName = Which Mod Is This From? (WMITF)
 author = gardenapple
-version = 2.7.0
+version = 2.7.1
 homepage = http://forums.terraria.org/index.php?threads/vanilla-tweaks-other-little-tweak-mods.37443/#WMITF
 hideResources = false
 hideCode = false


### PR DESCRIPTION
- Modloader update reserved "ModName:". so I had to flip it.
- I also lessened the chance of tooltip ID conflict. that was my first attempt to fix the issue and left it as is.